### PR TITLE
fixed a bug where items added into the crafting grid could be voided

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorageaddons/item/WirelessCraftingGrid.java
+++ b/src/main/java/com/refinedmods/refinedstorageaddons/item/WirelessCraftingGrid.java
@@ -151,4 +151,14 @@ public class WirelessCraftingGrid extends WirelessGrid {
     public void removeCraftingListener(ICraftingGridListener listener) {
         listeners.remove(listener);
     }
+
+    @Override
+    public void onClosed(PlayerEntity player) {
+        if (!getStack().hasTag()) {
+            getStack().setTag(new CompoundNBT());
+        }
+
+        StackUtils.writeItems(matrix, 1, getStack().getTag());
+        super.onClosed(player);
+    }
 }


### PR DESCRIPTION
When adding to an existing stack inside the crafting container `onCraftingMatrixChanged` does not get called (as for vanilla this doesn't make a difference). 

This means items can be voided in some rare cases. See report here: <https://github.com/NillerMedDild/Enigmatica6/issues/774>

Saving contents on close is not ideal but since removing partial stacks actually does call `onCraftingMatrixChanged` this can only be abused (by removing the item from inventory while it is open) to void items not to dupe any. 